### PR TITLE
Temp fix Resource Manager default height

### DIFF
--- a/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/dnn-resource-manager.scss
+++ b/DNN Platform/Modules/ResourceManager/ResourceManager.Web/src/components/dnn-resource-manager/dnn-resource-manager.scss
@@ -9,7 +9,8 @@
   flex-direction: column;
   dnn-vertical-splitview{
     width: 100%;
-    height: 400px;
+    height: calc(100vh - 25rem);
+    min-height: 30rem;
     --left-pane-background-color: lightgray;
     --right-pane-background-color: white;
     .splitter{


### PR DESCRIPTION
Temporary fix for next patch release to give the Resource Manager a better default height.

In brief, the default height is currently hard-coded to 400px. This CSS-only fix instead bases the height on the browser's height using "100vh - 25rem" which basically means the resource manager's height will be (dynamically) about 400px less than the browser's height (to account for the theme's header and footer at least). We've also set a min-height of 30rem (appx 480px).

Read Issue #5361 for more details.
https://github.com/dnnsoftware/Dnn.Platform/issues/5361

<!-- 
  Please read contribution guideline first: https://github.com/dnnsoftware/Dnn.Platform/blob/develop/CONTRIBUTING.md 
-->

<!-- 
  Please make sure that there is a corresponding issue created and reference it in the PR by writing
  `Fixes #123` or `Closes #123`. 
  A PR without an accompanying issue will be accepted and merged on a very rare occasion
-->


## Summary
<!-- 
  Please describe the code changes as you see fit so that the reviewers have an easier task understanding what changed and why.
  New unit tests will be highly appreciated.
-->
